### PR TITLE
Fix svelte.config.js to support the latest version of Sveltekit

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -65,7 +65,7 @@ const config = {
 			crawl: true,
 			enabled: true,
 			onError: 'fail',
-			pages: ['*'],
+			entries: ['*'],
 		},
 		vite: () => ({
 			resolve: {


### PR DESCRIPTION
According to https://github.com/sveltejs/kit/pull/2380 and https://github.com/sveltejs/kit/issues/2185 , In version 1.0.0-next.165 and up, `prerender.pages` is now `prerender.entries`. I ran the latest version of sveltekit on this template and it failed with error:

> config.kit.prerender.pages has been renamed to `entries`.

Please consider merging this if people are using next... I'm not sure if this project is targeting stable, so I'll leave the small change here.
Thanks.