### PR TITLE
Update svelte.config.js

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -65,7 +65,7 @@ const config = {
 			crawl: true,
 			enabled: true,
 			onError: 'fail',
-			pages: ['*'],
+			entries: ['*'],
 		},
 		vite: () => ({
 			resolve: {


### PR DESCRIPTION
config.kit.prerender.pages has been renamed to `entries`.